### PR TITLE
chore: update CHANGELOG, bump version to rc 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,116 @@
+# v2.0.0-rc.12
+
+This is our fourth release candidate for this project. This project should be considered `pre-release` until we've released the final 2.0.0 version.
+
+This version should be used with `v2.0.0-rc.12` of https://github.com/reactioncommerce/reaction
+
+# Improvements
+
+## Feature
+
+- feat: always send a response to logout requests (#520)
+- feat: add Orders to Account Profile (#507)
+
+## Fix 
+
+- fix: de-duplicate styled-components package (#542)
+- fix: only run snyk when package.json changes (#541)
+- fix: change calibre ci step to use npx (#535)
+- fix: prettier config was in the wrong place (#532)
+- feat: remove unused fields from GQL query (#527)
+- fix: Update component theming example remove blocking code to allow starterkit to start (#514)
+
+## Chore
+
+- chore: removes fossa status from readme (#545)
+- chore: rename project to example-storefront (#544)
+- chore: fix debugger command in README (#539)
+- chore: change pinned deps to ~ ranges (#538)
+- chore: match license from LICENSE.md and README (#536)
+- chore: Switch to semver ~1.2.3 style ranges (#534)
+- chore: update yarn.lock to resolve snyk js-yaml vuln (#531)
+- chore: ignore snyk js-yaml vuln for 30 days (#523)
+
+## Docs
+
+- docs: remove production warning (#543)
+- docs: add instructions on how to run starterkit w/ prod API (#537)
+- docs: Fix minor typo on [README.md](http://readme.md) (#525)
+
+# v2.0.0-rc.11
+
+This is our third release candidate for this project. This project should be considered `pre-release` until we've released the final 2.0.0 version.
+
+This version should be used with `v2.0.0-rc.11` of https://github.com/reactioncommerce/reaction
+
+# Improvements
+
+## Feature
+
+- feat: add Orders to Account Profile (#507)
+
+## Fix
+
+- fix: Update component theming example (#511)
+
+## Chore
+
+- chore: remove blocking code to allow starterkit to start (#514)
+
+# v2.0.0-rc.10
+
+This is our second release candidate for this project. This project should be considered `pre-release` until we've released the final 2.0.0 version.
+
+This version should be used with `v2.0.0-rc.10` of https://github.com/reactioncommerce/reaction
+
+# Improvements
+
+### Dev Utilities
+
+- We have made it easier to debug and troubleshoot issues in our Docker image:
+  (#504)
+
+### General
+
+- We added a new new profile address book page (#499)
+- We added support for GraphQL Subscriptions (#492)
+- We added the ability to get sitemap data from GQL API and make it available on sitemap\*.xml routes (#488)
+- We added the ability to have surcharges attached to an order (#499)
+
+# Breaking Changes
+
+### Multiple Payment Support
+
+- All of the individual `placeOrder*` GraphQL mutations provided by the built-in payment plugins are removed and replaced with a single `placeOrder` mutation which supports multiple payments. Any custom payment method plugins will break due to the removal of `createOrder` internal mutation. Look at all changes. (https://github.com/reactioncommerce/reaction/pull/4908)
+
+## Feature
+
+- feat: performance metrics integration with calibre (#508)
+- feat: add dev utilities to the docker image (#504)
+- feat: new Profile Address page (#499)
+- feat: add graphql subscription support (#492)
+- feat: setup sitemap routes to get data from GQL server (#488)
+- feat: display order surcharges in UI (#449)
+
+## Fixes
+
+- fix: add enhancements to sitemap route handling (#497)
+- fix: updated dependencies and snyk policies (#496)
+
+## Refactor
+
+- refactor: update checkout to support multiple payments (#477)
+- refactor: navigation data comes from new NavigationTree (#472)
+
+## Chore
+
+- chore: update typography variants based on MUI warning (#506)
+- chore: updated config for modules and tree shaking (#495)
+
+## Docs
+
+- docs(tags): update tag docs to include sitemap, isVisible (#505)
+
 # v2.0.0-rc.9
 This is our first release candidate for this project - we're going to be synchronizing releases across the differents parts of the Reaction Commerce ecosystem, so that's why we're starting with rc.8. This project should be considered `pre-release` until we've released the final 2.0.0 version.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "2.0.0-rc.9",
+  "version": "2.0.0-rc.12",
   "description": " ",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
The updates to CHANGELOG and version weren't put into develop branch due to the rc candidate being cut develop -> rc -> master before.

- Updated CHANGELOG to include RC10, RC11, and RC12
- Bump Version for RC 12 from RC 9 on Develop