### PR TITLE
Add 302 redirects to env.EXTERNAL_GRAPHQL_URL

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -42,7 +42,7 @@ app
 
     // add graphiql redirects to EXTERNAL_GRAPHQL_URL
     server.get(["/graphiql", "/graphql-beta", "/graphql-alpha", "/graphql"], (req, res) => {
-      res.redirect(config.EXTERNAL_GRAPHQL_URL);
+      res.redirect(301, config.EXTERNAL_GRAPHQL_URL);
     });
 
     // apply to routes starting with "/sitemap" and ending with ".xml"

--- a/src/server.js
+++ b/src/server.js
@@ -41,8 +41,8 @@ app
     configureAuthForServer(server);
 
     // add graphiql redirects to EXTERNAL_GRAPHQL_URL
-    server.get( ['/graphiql', '/graphql-beta', '/graphql-alpha', '/graphql' ], (req,res) => {
-      res.redirect( config.EXTERNAL_GRAPHQL_URL );
+    server.get(["/graphiql", "/graphql-beta", "/graphql-alpha", "/graphql"], (req, res) => {
+      res.redirect(config.EXTERNAL_GRAPHQL_URL);
     });
 
     // apply to routes starting with "/sitemap" and ending with ".xml"

--- a/src/server.js
+++ b/src/server.js
@@ -40,6 +40,11 @@ app
 
     configureAuthForServer(server);
 
+    // add graphiql redirects to EXTERNAL_GRAPHQL_URL
+    server.get( ['/graphiql', '/graphql-beta', '/graphql-alpha', '/graphql' ], (req,res) => {
+      res.redirect( config.EXTERNAL_GRAPHQL_URL );
+    });
+
     // apply to routes starting with "/sitemap" and ending with ".xml"
     server.use(/^\/sitemap.*\.xml$/, sitemapRoutesHandler);
 


### PR DESCRIPTION
Signed-off-by: Christopher Shepherd <christopher@reactioncommerce.com>

Resolves #549 
Impact: **minor**
Type: **feature**

## Issue
Adds 302 redirects for a few paths via express.js

## Solution
Added redirects at the express.js level rather than the next.js router because I don't see a downside to it, and it's easy to express in just a few lines of code.

## Breaking changes
none

## Testing
1. curl -i http://localhost:4000/graphiql (or /graphql, or /graphql-alpha or /graphql-beta)
2. Observe HTTP 302 redirect to EXTERNAL_GRAPHQL_URL
