### PR TITLE
hotfix: prevent app crash on PDP page.

### DIFF
--- a/src/components/VariantList/VariantList.js
+++ b/src/components/VariantList/VariantList.js
@@ -86,7 +86,7 @@ export default class VariantList extends Component {
     }
 
     // If we don't have an option, use the variant for inventory status information
-    if (selectedVariantId) {
+    if (selectedVariant && selectedVariantId) {
       return <InventoryStatus product={selectedVariant} />;
     }
 


### PR DESCRIPTION
Resolves #5263

Prevent crash on PDP page caused by not checking for variant existence before passing to inventory status component.

## Testing

1. Start reaction
2. Go to homepage
3. Go to product
4. Go back to home page
5. Go to other product
6. Verify PDP does not crash

