### PR TITLE
feat: match userid between host and container

### DIFF
--- a/.reaction/entrypoint.sh
+++ b/.reaction/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+uid=$(echo "${REACTION_USER:-1000:1000}" | cut -d : -f 1)
+usermod --uid "${uid}" --non-unique node |& grep -v "no changes" || true
+command=("./bin/start")
+if [[ $# -gt 0 ]]; then
+  command=($@)
+fi
+unset IFS
+exec su-exec node ${command[*]}

--- a/.reaction/fix-volumes.sh
+++ b/.reaction/fix-volumes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+uid=$(echo "${REACTION_USER:-1000:1000}" | cut -d : -f 1)
+volumes=(
+  ../node_modules
+  ./build
+  /home/node/.cache/yarn-offline-mirror
+  /home/node/.cache/yarn
+)
+for dir in ${volumes[*]}; do
+  printf "Fixing volume ${dir} (uid ${uid})…"
+  mkdir -p "${dir}"
+  chown -R node "${dir}"
+  chmod -R a+r,u+rw "${dir}"
+  echo "✓"
+done

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,9 @@ LABEL maintainer="Reaction Commerce <engineering@reactioncommerce.com>" \
       com.reactioncommerce.docker.git.sha1=$GIT_SHA1 \
       com.reactioncommerce.docker.license=$LICENSE
 
-RUN apk --no-cache add bash curl less vim
+# shadow and su-exec are used by bin/start-root (shadow provides usermod)
+# hadolint ignore=DL3018
+RUN apk --no-cache add bash curl less shadow su-exec vim
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-u", "-c"]
 
 # Because Docker Compose uses a volume for node_modules and volumes are owned
@@ -113,4 +115,6 @@ RUN if [ "$BUILD_ENV" = "production" ]; then \
     yarn build; \
   fi;
 
-CMD ["yarn", "start"]
+# hadolint ignore=DL3002
+USER root
+ENTRYPOINT ["./.reaction/entrypoint.sh"]

--- a/bin/fix-volumes
+++ b/bin/fix-volumes
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Please Use Google Shell Style: https://google.github.io/styleguide/shell.xml
+
+# ---- Start unofficial bash strict mode boilerplate
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # always exit on error
+set -o errtrace # trap errors in functions as well
+set -o pipefail # don't ignore exit codes when piping output
+set -o posix    # more strict failures in subshells
+# set -x          # enable debugging
+
+IFS=$'\n\t'
+# ---- End unofficial bash strict mode boilerplate
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+docker-compose down
+# Important to ensure REACTION_USER is set properly, so run setup
+./bin/setup
+docker-compose run --user=root --entrypoint=./.reaction/fix-volumes.sh web

--- a/bin/fix-volumes
+++ b/bin/fix-volumes
@@ -13,7 +13,6 @@ set -o posix    # more strict failures in subshells
 IFS=$'\n\t'
 # ---- End unofficial bash strict mode boilerplate
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-docker-compose down
 # Important to ensure REACTION_USER is set properly, so run setup
 ./bin/setup
 docker-compose run --user=root --entrypoint=./.reaction/fix-volumes.sh web

--- a/bin/fix-volumes
+++ b/bin/fix-volumes
@@ -15,4 +15,4 @@ IFS=$'\n\t'
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # Important to ensure REACTION_USER is set properly, so run setup
 ./bin/setup
-docker-compose run --user=root --entrypoint=./.reaction/fix-volumes.sh web
+docker-compose run --entrypoint=./.reaction/fix-volumes.sh web

--- a/bin/setup
+++ b/bin/setup
@@ -4,27 +4,47 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 env_file=${__dir}/../.env
 env_example_file=${__dir}/../.env.example
 
-function main {
+function main() {
   set -e
 
   add_new_env_vars
+  add_reaction_user
 }
 
-function add_new_env_vars {
+function add_new_env_vars() {
   # create .env and set perms if it does not exist
-  [ ! -f "${env_file}" ] && { touch "${env_file}" ; chmod 0600 "${env_file}" ; }
+  if [[ ! -f "${env_file}" ]]; then
+    touch "${env_file}"
+    chmod 0600 "${env_file}"
+  fi
 
-  export IFS=$'\n'
-  for var in $(cat "${env_example_file}"); do
-    key="${var%%=*}"     # get var key
+  while IFS=$'\n' read -r var; do
+    key="${var%%=*}"        # get var key
     var=$(eval echo "$var") # generate dynamic values
 
     # If .env doesn't contain this env key, add it
-    if ! $(grep -qLE "^$key=" "${env_file}"); then
+    if ! grep -qLE "^$key=" "${env_file}"; then
       echo "Adding $key to .env"
-      echo "$var" >> "${env_file}"
+      echo "$var" >>"${env_file}"
     fi
-  done
+  done <"${env_example_file}"
+}
+
+function add_reaction_user() {
+  if grep -qLE "^REACTION_USER" "${env_file}"; then
+    # line is already present, leave unchanged
+    return
+  fi
+  # line is not present
+  if [[ -n "${REACTION_USER}" ]]; then
+    # if set in environment, just add the name but no = and no value
+    line="REACTION_USER"
+  else
+    # if unset in environment, default to the current user's uid:gid
+    line="REACTION_USER=$(id -u):$(id -g)"
+  fi
+  echo "Adding ${line} to .env"
+  echo "${line}" >>"${env_file}"
 }
 
 main

--- a/bin/start
+++ b/bin/start
@@ -7,6 +7,8 @@ set -o pipefail # don't ignore exit codes when piping output
 IFS="$(printf "\n\t")"
 
 cd "$(dirname "$0")/.."
+export PATH=/usr/local/bin:/usr/bin:/bin
+export HOME=/home/node
 yarn install
 printf "Creating hydra client…"
 ./bin/wait-for.sh "${OAUTH2_HOST}:${OAUTH2_ADMIN_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,10 @@ networks:
 
 services:
   web:
-    user: root
     build:
       context: .
       args:
         BUILD_ENV: "development"
-    command: "/usr/local/src/reaction-app/bin/start"
     env_file:
       - ./.env
     environment:


### PR DESCRIPTION
Impact: **major**
Type: **feature|bugfix**

## Issue

On linux, the docker container runs as user `node` (uid 1000), which in many cases is not the same as the developer's host OS uid. This can cause mismatches in ownership of files that are shared between the host and the container via docker volume mounts. Ultimately this surfaces as filesystem errors (`EACCESS`, `permission denied`, etc) at various times including when trying to run `yarn`, do builds, etc.

**Why doesn't bug  affect all linux users?**

On many linux distributions, the first non-system user is assigned uid 1000. That's why in our docker container the `node` user has uid 1000, it's just a default. That's also why many developer's have uid 1000 as well: it's the default for the first non-system user on their distribution and their user is the first one they add when doing their OS install. Because of that default and coincidence many users avoid this issue because their uid just happens to match the one we use. (This was the case for me personally and why it is harder for me to encounter/reproduce these issues)

**Why doesn't this affect macOS users?**

Docker for Mac has automatic mapping that avoids this issue largely.

**How does this apply to reaction core? Other repos?**

If testing proves successful in storefront, I believe this pattern would apply to reaction core and essentially every docker-based service we have that makes use of volume mounts, which is probably most but not all of them. I started with core initially as a fix there would have the widest impact, but the docker setup there is significantly more complex and with the slow startup time I switched to storefront as an easier first project to tackle.

## Related issues

- Storefront PR attempt from May 2019 (closed unmerged when problem was not solvable without a root entrypoint script)
  - https://github.com/reactioncommerce/example-storefront/pull/533#pullrequestreview-
- many users in the community hitting a version of this issue starting in Oct 2018
  - Specifically: `Error creating Reaction config file: /opt/reaction/src/.reaction/config.json`
  - https://github.com/reactioncommerce/reaction-platform/issues/14
- Me hitting a loosely-related issue in storefront
  - https://github.com/reactioncommerce/reaction-platform/issues/7
- community user issue
  - https://github.com/reactioncommerce/reaction/issues/5510

## Solution

The key elements of the solution are:

- Create an env var mechanism so inside docker we can know the host uid
- Start the docker process as root
- During container startup, modify the `node` user account in the container to have the matching uid
change ownership and permissions on all necessary directories to the matching uid
- `su-exec` to `node` in the container then proceed to launch the application
- Provide a `./bin/fix-volumes` script that can be run at any time that will `chown`/`chmod` all volume mount directories properly and should be a 1-stop fix to this entire category of errors

There are a ton of unix heavy details in here we should scrutinize during code review.

Some things to note about the solution (pending QA testing)

- The goal here is to have things "just work" in all cases
- File owners and permissions on the host filesystem will be changed when running `fix-volumes`
  - There's potential here for surprise or confusion in the user base, and perhaps "hey don't do that!"
- I believe the solution will handle pre-existing files in the volume mount directories with assorted owner/permission combinations and it should force them all to be correct, but I think there's a lot of testing surface here

## Breaking changes

I don't think anything here would count as "breaking" but the changed ownership/permission of host files could be surprising/unexpected as noted above.

## Testing

- Try a fresh `git clone` of this example-storefront branch, `./bin/setup`, and `docker-compose up`
  - Try on mac, linux with userid !=1000, linux with userid=1000
- Create some permutations of ownership mismatches and test the fix scripts.
  - Directories of interest include
    - `$HOME/.cache/yarn-offline-mirror`
    - `$HOME/.cache/yarn`
    - `example-storefront/node_modules`
    - `example-storefront/build`
- Note you may want to create a new user in your linux host for this to force non-1000 uid. On linux mint I was able to do this via the users & groups GUI (or you can use `adduser` CLI) and once I did `sudo adduser plyons2 docker` the new user could use  docker. Then I `sudo su - plyons2` to get a shell with that user for testing.
- Verify when the application finally loads that it is not running as root
  - `docker-compose run web ps -ef`
  - You will see some early `root` processes then a switch to `node` for the `bin/start`

**Example good output**
- Your container id may vary
- If everything is running as `root`, that's a bug

```
docker exec --interactive --tty rc-storefront_web_1 ps -ef
PID   USER     TIME  COMMAND
    1 root      0:00 su --preserve-environment --command /usr/local/src/reactio
   23 node      0:00 sh /usr/local/src/reaction-app/bin/start
   67 node      0:00 node /opt/yarn-v1.13.0/bin/yarn.js dev
   88 node      0:15 /usr/local/bin/node ./src/server.js
   99 root      0:00 ps -ef
```