### PR TITLE
fix: add on load stripe event listener

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -67,9 +67,16 @@ export default class App extends NextApp {
     }
 
     const { stripePublicApiKey } = publicRuntimeConfig;
-    if (stripePublicApiKey && window.Stripe) {
-      // eslint-disable-next-line react/no-did-mount-set-state
-      this.setState({ stripe: window.Stripe(stripePublicApiKey) });
+    if (stripePublicApiKey) {
+      if (window.Stripe) {
+        // eslint-disable-next-line react/no-did-mount-set-state
+        this.setState({ stripe: window.Stripe(stripePublicApiKey) });
+      } else {
+        document.querySelector("#stripe-js").addEventListener("load", () =>
+          // Create Stripe instance once Stripe.js loads
+          // eslint-disable-next-line react/no-did-mount-set-state
+          this.setState({ stripe: window.Stripe(stripePublicApiKey) }));
+      }
     }
   }
 

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -87,6 +87,7 @@ class HTMLDocument extends Document {
         innerHTML: provider.renderScript()
       })),
       {
+        id: "stripe-js",
         type: "text/javascript",
         src: "https://js.stripe.com/v3/"
       }


### PR DESCRIPTION
Signed-off-by: Jaka Maver <jm18457@gmail.com>

Resolves #563 
Impact: **major**
Type: **bugfix**

## Issue
When running example-storefront in production stripe event is not always loaded. This might be due to outside caching, or because stripe takes longer to be loaded.
I have added console logs in the else statement (with event listener) and in production environment they were called almost always.

## Solution
Add load event listener to set state for stripe in comonentDidMount.

## Breaking changes
No breaking changes.

## Testing
1. Enable stripe in admin dashboard.
2. In checkout go to step where you have to enter card information.
3. You should be able to enter credit card details.
