### PR TITLE
fix: e2e tests need a checkout step now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,7 @@ jobs:
   e2e-test:
     <<: *defaults
     steps:
+      - checkout
       - setup_remote_docker
       - attach_workspace:
           at: docker-cache


### PR DESCRIPTION
Fix broken e2e tests by adding a checkout step in circleci.
