### PR TITLE
chore: bump version to 2.4.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "The Example Storefront serves as a reference for implementing a web based storefront using the Reaction Commerce GraphQL API.",
   "main": "./src/server.js",
   "keywords": [],


### PR DESCRIPTION
# v2.4.0

Example Storefront v2.4.0 is a minor update to keep this project in sync with [Reaction v2.4.0](https://github.com/reactioncommerce/reaction) and [reaction-hydra v2.4.0](https://github.com/reactioncommerce/reaction-hydra)

## Features
feat: Use host uid:gid and use in docker to avoid file permissions problems [#576](https://github.com/reactioncommerce/example-storefront/pull/576)

## Fixes

fix: Resolve broken e2e tests by adding a checkout step in CircleCI [#580](https://github.com/reactioncommerce/example-storefront/pull/580)

## Breaking Changes

None