### PR TITLE
fix: restore empty_node_modules volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,13 @@ services:
       - $HOME/.cache/yarn-offline-mirror:/home/node/.cache/yarn-offline-mirror
       - web-yarn:/home/node/.cache/yarn
       - .:/usr/local/src/reaction-app
+      # Do not link in node_modules from the host
+      # This allows IDEs to run lint etc with native add-ons for host OS
+      # Without interfering with native add-ons in container
+      - empty_node_modules:/usr/local/src/reaction-app/node_modules
       - node_modules:/usr/local/src/node_modules
 
 volumes:
   web-yarn:
   node_modules:
+  empty_node_modules:


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
I removed this volume mount in some prior work not understanding it's necessity.

## Solution
Add it back with a comment justifying its existence.

## Breaking changes
N/A

## Testing
1. Bring up storefront (especially on mac)
1. Locally run `yarn` on your host
1. Configure your editor to use the project-specific eslint
1. Confirm IDE/editor based linting works OK from host OS
1. Confirm app runs fine in docker at same time