### PR TITLE
Release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v2.6.0
+
+Example Storefront v2.6.0 is a minor update to keep this project in sync with [Reaction v2.6.0](https://github.com/reactioncommerce/reaction) and [reaction-hydra v2.6.0](https://github.com/reactioncommerce/reaction-hydra)
+
+## Fixes
+
+fix: restore empty_node_modules volume [#591](https://github.com/reactioncommerce/example-storefront/pull/591)
+
 # v2.5.0
 
 Example Storefront v2.5.0 is a minor update to keep this project in sync with [Reaction v2.5.0](https://github.com/reactioncommerce/reaction) and [reaction-hydra v2.5.0](https://github.com/reactioncommerce/reaction-hydra)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,13 @@ services:
       - $HOME/.cache/yarn-offline-mirror:/home/node/.cache/yarn-offline-mirror
       - web-yarn:/home/node/.cache/yarn
       - .:/usr/local/src/reaction-app
+      # Do not link in node_modules from the host
+      # This allows IDEs to run lint etc with native add-ons for host OS
+      # Without interfering with native add-ons in container
+      - empty_node_modules:/usr/local/src/reaction-app/node_modules
       - node_modules:/usr/local/src/node_modules
 
 volumes:
   web-yarn:
   node_modules:
+  empty_node_modules:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "The Example Storefront serves as a reference for implementing a web based storefront using the Reaction Commerce GraphQL API.",
   "main": "./src/server.js",
   "keywords": [],


### PR DESCRIPTION
# v2.6.0

Example Storefront v2.6.0 is a minor update to keep this project in sync with [Reaction v2.6.0](https://github.com/reactioncommerce/reaction) and [reaction-hydra v2.6.0](https://github.com/reactioncommerce/reaction-hydra