### PR TITLE
[3.0.0] Fix params for withTag API query

### DIFF
--- a/src/components/CheckoutActions/CheckoutActions.js
+++ b/src/components/CheckoutActions/CheckoutActions.js
@@ -36,6 +36,8 @@ const MessageDiv = styled.div`
 
 const NoPaymentMethodsMessage = () => <MessageDiv>No payment methods available</MessageDiv>;
 
+NoPaymentMethodsMessage.renderComplete = () => "";
+
 @withAddressValidation
 @track()
 @observer

--- a/src/containers/tags/tag.gql
+++ b/src/containers/tags/tag.gql
@@ -1,7 +1,7 @@
 #import "./tagFragment.gql"
 
-query tagQuery($slugOrId: String) {
-  tag(slugOrId: $slugOrId) {
+query tagQuery($shopId: ID!, $slugOrId: String!) {
+  tag(shopId: $shopId, slugOrId: $slugOrId) {
     ...TagInfo
   }
 }

--- a/src/containers/tags/withTag.js
+++ b/src/containers/tags/withTag.js
@@ -12,10 +12,11 @@ import tagQuery from "./tag.gql";
  * @returns {React.Component} - Component with `tag` prop
  */
 export default function withTag(Component) {
-  @inject("routingStore")
+  @inject("primaryShopId", "routingStore")
   @observer
   class WithTag extends React.Component {
     static propTypes = {
+      primaryShopId: PropTypes.string.isRequired,
       /**
        * slug used to obtain tag info
        */
@@ -27,14 +28,19 @@ export default function withTag(Component) {
 
     render() {
       const {
+        primaryShopId,
         router: { query: { slug: slugFromQueryParam } },
         routingStore: { tagId }
       } = this.props;
 
       const slugOrId = slugFromQueryParam || tagId;
 
+      if (!primaryShopId || !slugOrId) {
+        return <Component {...this.props} />;
+      }
+
       return (
-        <Query query={tagQuery} variables={{ slugOrId }}>
+        <Query query={tagQuery} variables={{ shopId: primaryShopId, slugOrId }}>
           {({ error, data }) => {
             if (error) {
               console.error("WithTag query error:", error); // eslint-disable-line no-console


### PR DESCRIPTION
Resolves #620 
Impact: **minor**
Type: **bugfix**

## Issue
Due to breaking changes in the 3.0 `tag` GraphQL query, the example storefront does not load.

## Solution
Update client query to match API.

## Breaking changes
Yes, this won't work with 2.x API, but this is the 3.0 branch.

## Testing
Verify storefront loads in browser when connected with `release-3.0.0` branch of API, and you don't see any errors in the API or storefront server logs.