### PR TITLE
fix: made bin/setup always run from the desired path

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-env_file=${__dir}/../.env
-env_example_file=${__dir}/../.env.example
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+env_file=./.env
+env_example_file=./.env.example
 
 function main {
   set -e


### PR DESCRIPTION
Impact: **major**  
Type: **bugfix**

## Issue

The general problem is that the `find` used in `bin/setup` is run from the PWD the script is run from.
The expected outcome is that `bin/setup` should only copy environment variables found within this project.

Right now running `make init` in reaction-platform copies the environment variables from _every_ project's `.env.example` files into almost every `.env` file of every other project.
This is because in this case the `find` command used to find all `.env.example` files is being run from the platform directory, and thus all cloned projects within it are found by the `find`.

## Solution

I made `bin/setup` `cd` to the root of the project before running the `find`.
This also prevents us from needing the `$__dir` variable we were using when referring to files within the script.

## Testing

1. Run `bin/setup` from the root of this project (which is the only place it used to work from).
2. Run `bin/setup` from any other folder, such as `reaction-platform` or a folder that contains other reaction projects.

For both of these cases, verify that your working directory does not change. It shouldn't, because the `cd` happens within a function and is not expected to affect your shell directory.