### PR TITLE
chore: use published image for docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ src/.next/*
 build
 /reports
 
-package-lock.json
+docker-compose.override.yml

--- a/bin/start-prod.sh
+++ b/bin/start-prod.sh
@@ -7,6 +7,7 @@ set -o pipefail # don't ignore exit codes when piping output
 IFS="$(printf "\n\t")"
 
 cd "$(dirname "$0")/.."
-yarn install
-./bin/create-hydra-client.sh
-yarn start:dev
+printf "Creating hydra client…"
+./bin/wait-for.sh "${OAUTH2_HOST}:${OAUTH2_ADMIN_PORT}"
+./bin/create-hydra-client.js
+node .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,26 @@
+# This docker-compose file is used to run the project in Docker for development.
+# The local files are mounted into the created container.
+#
+# Usage:
+#  ln -s docker-compose.dev.yml docker-compose.override.yml
+#  docker-compose up [-d]
+#
+# To go back to running the published image:
+#  rm docker-compose.override.yml
+
+version: '3.4'
+
+services:
+  web:
+    image: reactioncommerce/node-dev:10.16.3-v2
+    volumes:
+      - .:/usr/local/src/app
+      - web-yarn:/home/node/.cache/yarn
+      # Do not link in node_modules from the host
+      # This allows IDEs to run lint etc with native add-ons for host OS
+      # Without interfering with native add-ons in container
+      - empty_node_modules:/usr/local/src/app/node_modules
+
+volumes:
+  web-yarn:
+  empty_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-# This docker-compose file is used to run the Example Storefront in Docker for development.
-# The local files are mounted into the created container.
+# This docker-compose file is used to run the project's published image
+#
 # Usage: docker-compose up [-d]
+#
+# See comment in docker-compose.dev.yml if you want to run for development.
 
 version: '3.4'
 
@@ -8,30 +10,26 @@ networks:
   api:
     external:
       name: api.reaction.localhost
-  auth.reaction.localhost:
+  auth:
     external:
       name: auth.reaction.localhost
 
 services:
   web:
-    image: reactioncommerce/node-dev:10.16.3-v2
+    image: reactioncommerce/example-storefront:release-v3.0.0
+    # The only reason we need to override the command is to auto-create
+    # the Hydra client if it doesn't exist. In the future, we plan to
+    # make this logic part of the codebase, at which point this can be
+    # removed.
+    command: "./bin/start-prod.sh"
     env_file:
       - ./.env
     networks:
       api:
-        aliases:
-          - storefront
-      auth.reaction.localhost:
+      auth:
     ports:
       - 4000:4000
     volumes:
-      - web-yarn:/home/node/.cache/yarn
-      - .:/usr/local/src/app
-      # Do not link in node_modules from the host
-      # This allows IDEs to run lint etc with native add-ons for host OS
-      # Without interfering with native add-ons in container
-      - empty_node_modules:/usr/local/src/app/node_modules
-
-volumes:
-  web-yarn:
-  empty_node_modules:
+      # This volume is needed only to run the `command` above.
+      # When the command is removed, this volume can also be removed.
+      - ./bin:/usr/local/src/app/bin


### PR DESCRIPTION
Impact: **minor**
Type: **chore**

## Changes
When you clone this branch and run `docker-compose up`, it will now pull and use the latest published `reactioncommerce/example-storefront:release-v3.0.0` image from DockerHub instead of `node-dev`. Host files are not linked in, NPM deps are not reinstalled, and NextJS will run in the faster production mode unless you set `NODE_ENV=development` in your `.env` file.

## Breaking changes
Breaking only for devs who will now need to run `ln -s docker-compose.dev.yml docker-compose.override.yml` to get the previous behavior.

## Testing
- Verify `dc up` starts quickly and in prod mode. (You should not see anything about compiling pages in the logs.)
- After `dc down`, run `ln -s docker-compose.dev.yml docker-compose.override.yml` and then `dc up` again. Verify it now starts in dev mode and reloads when you change files.
- After `dc down`, run `rm docker-compose.override.yml` to remove the override file. It should be back to running in prod mode when you do `dc up`.