### PR TITLE
fix: update param name which was missed

### DIFF
--- a/src/containers/cart/queries.gql
+++ b/src/containers/cart/queries.gql
@@ -1,8 +1,8 @@
 #import "./fragments.gql"
 
 # Get an anonymous cart by the anonymous cartId and and an anonymous cart token
-query anonymousCartByCartIdQuery($cartId: ID!, $token: String!, $itemsAfterCursor: ConnectionCursor) {
-  cart: anonymousCartByCartId(cartId: $cartId, token: $token) {
+query anonymousCartByCartIdQuery($cartId: ID!, $cartToken: String!, $itemsAfterCursor: ConnectionCursor) {
+  cart: anonymousCartByCartId(cartId: $cartId, cartToken: $cartToken) {
     ...CartQueryFragment
   }
 }

--- a/src/containers/cart/withCart.js
+++ b/src/containers/cart/withCart.js
@@ -161,7 +161,7 @@ export default function withCart(Component) {
         const { anonymousCartId, anonymousCartToken } = cartStore;
 
         // Add items to an existing anonymous cart
-        input.token = anonymousCartToken;
+        input.cartToken = anonymousCartToken;
         input.cartId = anonymousCartId;
       } else if (!isCreating && authStore.isAuthenticated && cartStore.hasAccountCart) {
         // With an account and an account cart, set the accountCartId on the input object


### PR DESCRIPTION
Impact: **major**
Type: **bugfix**

## Issue
Storefront was unusable because carts weren't being create / read due to missing one instance when renaming a param.

## Solution
Update the param name.


## Breaking changes
None

## Testing
1. See that you can add items to cart on storefront 