### PR TITLE
fix: login from storefront

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ OAUTH2_CLIENT_ID=example-storefront
 OAUTH2_CLIENT_SECRET=CHANGEME
 OAUTH2_HOST=hydra.auth.reaction.localhost
 OAUTH2_IDP_HOST_URL=http://reaction.api.reaction.localhost:3000/
+OAUTH2_LOGOUT_URL=http://localhost:3000/account/logout
 OAUTH2_REDIRECT_URL=http://localhost:4000/callback
 OAUTH2_TOKEN_URL=http://hydra.auth.reaction.localhost:4444/oauth2/token
 PORT=4000

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,7 @@ if (process.env.IS_BUILDING_NEXTJS) {
     OAUTH2_CLIENT_ID: str(),
     OAUTH2_CLIENT_SECRET: str(),
     OAUTH2_IDP_HOST_URL: url(),
+    OAUTH2_LOGOUT_URL: url(),
     OAUTH2_REDIRECT_URL: url(),
     OAUTH2_TOKEN_URL: url(),
     PORT: port({ default: 4000 }),

--- a/src/serverAuth.js
+++ b/src/serverAuth.js
@@ -94,7 +94,8 @@ function configureAuthForServer(server) {
         }
         // If IDP confirmed logout, clear login info on this side
         req.logout();
-        res.redirect(req.get("Referer") || "/");
+        const referer = req.get("Referer");
+        res.redirect(`${config.OAUTH2_LOGOUT_URL}?referer=${referer}` || "/");
         return; // appease eslint consistent-return
       })
       .catch((error) => {


### PR DESCRIPTION
See https://github.com/reactioncommerce/reaction/pull/5951

Impact: **critical**  
Type: **bugfix**

You need to be [this branch of Reaction](https://github.com/reactioncommerce/reaction/pull/5951) when testing. That PR and this one should be merged at the same time.

## Issue
Account login was not working when trying to login via example storefront.

## Solution
Add `oauth` login method to new `AuthContainer`. This is how we used to do oauth login in the past, when we used `OauthContainer`, but this was removed / with the new `AuthContainer`.

## Breaking changes
None

## Testing
1. Start the full app (reaction (https://github.com/reactioncommerce/reaction/pull/5951) / storefront)
1. Navigate to storefront
1. Login
1. See you are redirected back to storefront, and you are logged in
1. Logout
1. See you are redirected back to storefront, and are logged out
