### PR TITLE
Change password and logout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,10 @@ OAUTH2_ADMIN_URL=http://hydra.auth.reaction.localhost:4445
 OAUTH2_AUTH_URL=http://localhost:4444/oauth2/auth
 OAUTH2_CLIENT_ID=example-storefront
 OAUTH2_CLIENT_SECRET=CHANGEME
+OAUTH2_PUBLIC_LOGOUT_URL=http://localhost:4444/oauth2/sessions/logout
 OAUTH2_HOST=hydra.auth.reaction.localhost
 OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL=http://localhost:4100/account/change-password?email=EMAIL&from=FROM
 OAUTH2_IDP_HOST_URL=http://identity.auth.reaction.localhost:4100
-OAUTH2_REDIRECT_URL=http://localhost:4000/callback
 OAUTH2_TOKEN_URL=http://hydra.auth.reaction.localhost:4444/oauth2/token
 PORT=4000
 SEGMENT_ANALYTICS_SKIP_MINIMIZE=true

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ OAUTH2_AUTH_URL=http://localhost:4444/oauth2/auth
 OAUTH2_CLIENT_ID=example-storefront
 OAUTH2_CLIENT_SECRET=CHANGEME
 OAUTH2_HOST=hydra.auth.reaction.localhost
+OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL=http://localhost:4100/account/change-password?email=EMAIL&from=FROM
 OAUTH2_IDP_HOST_URL=http://identity.auth.reaction.localhost:4100
 OAUTH2_REDIRECT_URL=http://localhost:4000/callback
 OAUTH2_TOKEN_URL=http://hydra.auth.reaction.localhost:4444/oauth2/token

--- a/src/components/AccountDropdown/AccountDropdown.js
+++ b/src/components/AccountDropdown/AccountDropdown.js
@@ -78,6 +78,11 @@ class AccountDropdown extends Component {
                     Profile
                   </Button>
                 </div>
+                <div className={classes.marginBottom}>
+                  <Button color="primary" fullWidth href={`/change-password?email=${encodeURIComponent(account.emailRecords[0].address)}`}>
+                    Change Password
+                  </Button>
+                </div>
                 <Button color="primary" fullWidth href={`/logout/${account._id}`} variant="contained">
                   Sign Out
                 </Button>

--- a/src/components/AccountDropdown/AccountDropdown.js
+++ b/src/components/AccountDropdown/AccountDropdown.js
@@ -83,7 +83,7 @@ class AccountDropdown extends Component {
                     Change Password
                   </Button>
                 </div>
-                <Button color="primary" fullWidth href={`/logout/${account._id}`} variant="contained">
+                <Button color="primary" fullWidth href="/logout" variant="contained">
                   Sign Out
                 </Button>
               </Fragment>

--- a/src/config.js
+++ b/src/config.js
@@ -39,7 +39,7 @@ if (process.env.IS_BUILDING_NEXTJS) {
     OAUTH2_CLIENT_SECRET: str(),
     OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL: url(),
     OAUTH2_IDP_HOST_URL: url(),
-    OAUTH2_REDIRECT_URL: url(),
+    OAUTH2_PUBLIC_LOGOUT_URL: url(),
     OAUTH2_TOKEN_URL: url(),
     PORT: port({ default: 4000 }),
     SEGMENT_ANALYTICS_SKIP_MINIMIZE: bool({ default: false }),

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,7 @@ if (process.env.IS_BUILDING_NEXTJS) {
     OAUTH2_AUTH_URL: url(),
     OAUTH2_CLIENT_ID: str(),
     OAUTH2_CLIENT_SECRET: str(),
+    OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL: url(),
     OAUTH2_IDP_HOST_URL: url(),
     OAUTH2_REDIRECT_URL: url(),
     OAUTH2_TOKEN_URL: url(),

--- a/src/serverAuth.js
+++ b/src/serverAuth.js
@@ -1,7 +1,6 @@
 const OAuth2Strategy = require("passport-oauth2");
 const passport = require("passport");
 const config = require("./config");
-const { decodeOpaqueId } = require("./lib/utils/decoding");
 const logger = require("./lib/logger");
 
 let baseUrl = config.CANONICAL_URL;
@@ -112,7 +111,7 @@ function configureAuthForServer(server) {
     res.redirect(url);
   });
 
-  server.get("/logout", (req, res, next) => {
+  server.get("/logout", (req, res) => {
     req.session.redirectTo = req.get("Referer");
 
     const { idToken } = req.user || {};

--- a/src/serverAuth.js
+++ b/src/serverAuth.js
@@ -74,6 +74,21 @@ function configureAuthForServer(server) {
     res.redirect(req.session.redirectTo || "/");
   });
 
+  server.get("/change-password", (req, res) => {
+    const { email } = req.query;
+
+    let from = req.get("Referer");
+    if (typeof from !== "string" || from.length === 0) {
+      from = config.CANONICAL_URL;
+    }
+
+    let url = config.OAUTH2_IDP_PUBLIC_CHANGE_PASSWORD_URL;
+    url = url.replace("EMAIL", encodeURIComponent(email || ""));
+    url = url.replace("FROM", encodeURIComponent(from));
+
+    res.redirect(url);
+  });
+
   server.get("/logout/:userId", (req, res, next) => {
     const { userId } = req.params;
     if (!userId) {


### PR DESCRIPTION
Resolves #574 
Impact: **minor**
Type: **feature**

## Changes

## Breaking changes
These changes are tied to changes in Reaction Identity. As long as both services are updated as well as any environment variables, nothing should break.

This requires additional scope and options for the Hydra client, but I've included server startup code that will auto-update the Hydra client as necessary.

## Testing
Test with the following PR branches:
- https://github.com/reactioncommerce/reaction/pull/5991
- https://github.com/reactioncommerce/reaction-hydra/pull/42
- https://github.com/reactioncommerce/reaction-identity/pull/12

### Reset Password
Prerequisite: Configure emailing on the API so that you'll get the password reset email.

1. Create an account
2. Sign out
3. Click Sign In, but then click Forgot Password
4. Enter the email address of the account you created and click the button.
5. In the email, click the link.
6. Set a new password
7. Log in with the new password to confirm it worked.

### Change Password
1. Create an account or use already created.
2. Sign in
3. From account menu, choose Change Password.
4. You should be taken to the Change Password form on Reaction Identity with the email address pre-filled.
5. Enter your current and new password.
6. After the change, you should be automatically redirected back to the same storefront page you were on when you clicked Change Password.
7. Sign out and back in with the new password to verify it worked.

### Logout
If you've tested the other changes, you've been testing logout. The flow is different behind the scenes (standard OpenID Connect Logout Flow, more secure), but the effect is the same.

### Error Page
There is a custom OAuth error page now, but unless you modify the code or adjust some env variables you will hopefully not see it. If you are interested in doing this, let me know.