### PR TITLE
fix: special characters in variables

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ function add_new_env_vars {
   export IFS=$'\n'
   for var in $(cat "${env_example_file}"); do
     key="${var%%=*}"     # get var key
-    var=$(eval echo "$var") # generate dynamic values
+    var=$(command echo "$var") # generate dynamic values
 
     # If .env doesn't contain this env key, add it
     if ! $(grep -qLE "^$key=" "${env_file}"); then


### PR DESCRIPTION
Resolves #638
Impact: **minor**
Type: **bugfix**

## Issue

The `bin/setup` script doesn't handle special characters. Noticed examples are `$` and `&`.

## Solution

Used `command` instead of `eval`. There are a lot of reasons for this, and `eval` is generally frowned-upon. One such reason is it breaks when given "dirty" data.

## Breaking changes

I don't think there are any breaking changes with this.


## Testing

Run `bin/setup` and make sure everything is working as expected. I don't have an exhaustive list of what all that may be.