### PR TITLE
release v3.0.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v3.0.0-beta
+
+This is the beta release of our new Reaction project.
+
+*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
+
 # v3.0.0-alpha.3
 
 This is the latest alpha release of the Example Storefront that is designed to work with our new Reaction API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.0.0-beta
 
-This is the beta release of our new Reaction project.
+This is the beta release of the Example Storefront project that is designed to work with our new Reaction API.
 
 *Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "3.0.0-alpha.3",
+  "version": "3.0.0-beta",
   "description": "The Example Storefront serves as a reference for implementing a web based storefront using the Reaction Commerce GraphQL API.",
   "main": "./src/server.js",
   "keywords": [],


### PR DESCRIPTION
# v3.0.0-beta

This is the beta release of the Example Storefront project that is designed to work with our new Reaction API.

*Reaction releases will no longer be coordinated across all projects - we'll release each project, independently, as needed. This means version numbers will no longer be in sync. The newest versions of each project will work together. This change has two exceptions: we will release all projects in coordination for a `beta` release, and all projects in coordination for the official `v3.0.0` release.*