### PR TITLE
chore: update config files to prep for renaming default branch t…

### DIFF
--- a/.circleci/bin/docker-tags
+++ b/.circleci/bin/docker-tags
@@ -26,7 +26,7 @@ git show-ref --tags -d | grep "^${SHA1}" | sed -e 's,.* refs/tags/,,' -e 's/\^{}
   echo "%"
 
 # Tag with latest if certain conditions are met
-if [[ "$BRANCH" == "master" ]]; then
+if [[ "$BRANCH" == "trunk" ]]; then
   # Check to see if we have a valid `vX.X.X` tag and assign to CURRENT_TAG
   CURRENT_TAG=$( \
     git show-ref --tags -d \

--- a/.circleci/bin/should-run-snyk.sh
+++ b/.circleci/bin/should-run-snyk.sh
@@ -46,9 +46,9 @@ main() {
     echo "NO: Not a PR. Skipping Snyk."
     exit
   fi
-  # If target branch does not exist or is master, run snyk tests
-  if [[ ${TARGET_BRANCH} == "master" ]] || [[ -z "${TARGET_BRANCH/[ ]*\n/}" ]]; then
-    echo "YES: always run when targeting master"
+  # If target branch does not exist or is trunk, run snyk tests
+  if [[ ${TARGET_BRANCH} == "trunk" ]] || [[ -z "${TARGET_BRANCH/[ ]*\n/}" ]]; then
+    echo "YES: always run when targeting trunk"
     exit
   fi
   # If package.json is different from the base branch, run snyk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,4 +117,4 @@ workflows:
             - docker-build-push
           filters:
             branches:
-              only: /^master$/
+              only: /^trunk$/


### PR DESCRIPTION
To keep all of Reaction's main repositories in sync, we are renaming the default branches from `master` to `trunk`. This PR updates the config files that used `master` as the default.

Once this PR is merged, we should immediately make `trunk` the default branch of this repository.