### PR TITLE
docs: update links to use trunk branch of docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,4 +23,4 @@ Note any work that you did to mitigate the effect of any breaking changes such a
 2. Assume that testers already know how to start the app, and do the basic setup tasks.
 3. Be detailed enough that someone can work through it without being too granular
 
-More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction)
+More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/trunk/contributing-to-reaction)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,7 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by Reaction Commerce. This includes our [development chat room](https://gitter.im/reactioncommerce/reaction), [forums](https://forums.reactioncommerce.com), [blog](https://blog.reactioncommerce.com), mailing lists, [issue tracker](https://github.com/reactioncommerce/reaction/issues), [project boards](https://github.com/reactioncommerce/reaction/projects), Reaction events and meetups, and any other forums or service created by the core project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing <mailto:conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](https://docs.reactioncommerce.com/reaction-docs/master/reporting-guide).
+If you believe someone is violating the code of conduct, we ask that you report it by emailing <mailto:conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](https://docs.reactioncommerce.com/reaction-docs/trunk/reporting-guide).
 
 -   **Be friendly and patient.**
 
@@ -35,4 +35,4 @@ If you believe someone is violating the code of conduct, we ask that you report 
 
 ## Questions?
 
-If you have questions, please see the [FAQs](https://docs.reactioncommerce.com/reaction-docs/master/guideline-faqs). If that doesn't answer your questions, feel free to [contact us](mailto:hello@reactioncommerce.com).
+If you have questions, please see the [FAQs](https://docs.reactioncommerce.com/reaction-docs/trunk/guideline-faqs). If that doesn't answer your questions, feel free to [contact us](mailto:hello@reactioncommerce.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-At Reaction Commerce, we're dedicated to the open source community. In fact, we've designed our entire platform and business to grow from the passion and creativity that an open source community ignites. We've already attracted a small, dedicated team of open source contributors, and there's always room for more. 
+At Reaction Commerce, we're dedicated to the open source community. In fact, we've designed our entire platform and business to grow from the passion and creativity that an open source community ignites. We've already attracted a small, dedicated team of open source contributors, and there's always room for more.
 
-If you'd like to join us, check out our detailed [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction).
+If you'd like to join us, check out our detailed [Contributing Guide](https://docs.reactioncommerce.com/reaction-docs/trunk/contributing-to-reaction).
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ We love your pull requests! Check our our [`Good First Issue`](https://github.co
 Pull requests should pass all automated tests, style, and security checks.
 
 #### Automated Tests
-Your code should pass all [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/master/testing-reaction). Run
+Your code should pass all [acceptance tests and unit tests](https://docs.reactioncommerce.com/reaction-docs/trunk/testing-reaction). Run
 ```sh
 docker-compose run --rm web yarn test
 ```

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -19,4 +19,4 @@
 }
 ```
 
-For more on your getting started with GraphQL and Reaction: https://docs.reactioncommerce.com/reaction-docs/master/graphql-intro
+For more on your getting started with GraphQL and Reaction: https://docs.reactioncommerce.com/reaction-docs/trunk/graphql-intro


### PR DESCRIPTION
We updated the default / next branch of our docs repo: https://github.com/reactioncommerce/reaction-docs/pull/896

This PR updates all links to our docs to use this new branch.