### PR TITLE
fix: update query with required shopIds array

### DIFF
--- a/src/containers/order/queries.gql
+++ b/src/containers/order/queries.gql
@@ -8,7 +8,7 @@ query orderByReferenceId($id: ID!, $language: String!, $shopId: ID!, $token: Str
 }
 
 # Get orders by accountId
-query ordersByAccountIdQuery($accountId: ID!, $language: String!, $orderStatus: [String]! = ["all"], $shopIds: [ID], $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor) {
+query ordersByAccountIdQuery($accountId: ID!, $language: String!, $orderStatus: [String]! = ["all"], $shopIds: [ID]!, $first: ConnectionLimitInt, $last:  ConnectionLimitInt, $before: ConnectionCursor, $after: ConnectionCursor) {
   orders: ordersByAccountId(accountId: $accountId, orderStatus: $orderStatus, shopIds: $shopIds, first: $first, last: $last, before: $before, after: $after) {
     totalCount
     pageInfo {


### PR DESCRIPTION
Resolves #655
Impact: **major**
Type: **bugfix**

## Issue
Profile orders page doesn't load. Shows "500". There is an ordersByAccountId GraphQL error in the server logs:

## Solution
Update GQL query to use correct variables.

## Breaking changes
None

## Testing
1. Create an order
1. Go to http://localhost:4000/profile/orders while logged in with user who created order
1. See the order page, not an error