### PR TITLE
release 3.1.0

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,3 +1,6 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.4
+version: v1.13.5
 patch: {}
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v3.1.0
+
+This release of `example-storefront` is designed to work with v3.x of the Reaction API.
+
+### Chores
+
+- chore: bump https-proxy-agent from 2.2.2 to 2.2.4 ([#669](http://github.com/reactioncommerce/reaction-admin/pull/669))
+- chore: switch to 3.0.0 Docker tag ([#659](http://github.com/reactioncommerce/reaction-admin/pull/659))
+
 # v3.0.0
 
 This is the v3.0.0 release of `example-storefront`, designed to work with v3.0.0 of the Reaction API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   web:
-    image: reactioncommerce/example-storefront:3.0.0
+    image: reactioncommerce/example-storefront:3.1.0
     env_file:
       - ./.env
     networks:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The Example Storefront serves as a reference for implementing a web based storefront using the Reaction Commerce GraphQL API.",
   "main": "./src/server.js",
   "keywords": [],


### PR DESCRIPTION
# v3.1.0

This release of `example-storefront` is designed to work with v3.x of the Reaction API.

### Chores

- chore: bump https-proxy-agent from 2.2.2 to 2.2.4 ([#669](http://github.com/reactioncommerce/reaction-admin/pull/669))
- chore: switch to 3.0.0 Docker tag ([#659](http://github.com/reactioncommerce/reaction-admin/pull/659))