### PR TITLE
Use CANONICAL_URL for sitemap route

### DIFF
--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -1,6 +1,9 @@
 import fetch from "isomorphic-unfetch";
 import appConfig from "../../config.js";
 
+let shopUrl = appConfig.CANONICAL_URL;
+if (shopUrl.endsWith("/")) shopUrl = shopUrl.slice(0, -1);
+
 /**
  * Generates the sitemap and returns it
  *
@@ -9,7 +12,6 @@ import appConfig from "../../config.js";
  * @returns {String} the the sitemap
  */
 export default async function generateSitemap(req, res) {
-  const shopUrl = `${req.protocol}://${req.headers.host}`;
   const handle = req.url.replace("/", "");
 
   const query = `


### PR DESCRIPTION
Signed-off-by: Janus Reith <mail@janusreith.de>

Resolves #689
Impact: minor
Type: bugfix

## Issue
Sitemap routes currently show `undefined://` as `req.protocol` is not available in api routes.

## Solution
As detailed in #689, this will use `CANONICAL_URL` and pass it to the sitemap query instead of parsing the url from the incoming request.

## Breaking changes
None - I consider it unlikely that shops request sitemaps from a host name that differs from the one defined in `CANONICAL_URL`. If that is the case, these could adjust their sitemap api route individually.

## Testing
1. Make sure your api provides a sitemap
2. Navigate to http://localhost:4000/sitemap.xml and make sure it returns proper urls in the `loc` field.
