### PR TITLE
Return Not found if either product or shop are missing

### DIFF
--- a/pages/[lang]/product/[...slugOrId].js
+++ b/pages/[lang]/product/[...slugOrId].js
@@ -85,7 +85,7 @@ function ProductDetailPage({ addItemsToCart, product, isLoadingProduct, shop }) 
   }, [product, shop]);
 
   if (isLoadingProduct || router.isFallback) return <PageLoading />;
-  if (!product && !shop) return <Typography>Not Found</Typography>;
+  if (!product || !shop) return <Typography>Not Found</Typography>;
 
   return (
     <Layout shop={shop}>


### PR DESCRIPTION
Signed-off-by: Janus Reith <mail@janusreith.de>

Resolves #695
Impact: **critical**
Type: **bugfix**

## Issue
This should fix building the pdp for the default slug "-" during build

## Solution
If there is no product, the further tree of components in the tree shouldn't render, and a "Not found" message is shown instead.
Instead of checking if both product and shop are missing, return that message each time one of both is missing.

## Testing
1. Run the production build
2. Observe that the build finished properly