### PR TITLE
Revalidate index page, require instant revalidation if no shop is present during build

### DIFF
--- a/pages/[lang]/index.js
+++ b/pages/[lang]/index.js
@@ -95,11 +95,27 @@ class ProductGridPage extends Component {
  * @returns {Object} the props
  */
 export async function getStaticProps({ params: { lang } }) {
+  const primaryShop = await fetchPrimaryShop(lang);
+  const translations = await fetchTranslations(lang, ["common"]);
+
+  if (!primaryShop) {
+    return {
+      props: {
+        shop: null,
+        ...translations
+      },
+      // eslint-disable-next-line camelcase
+      unstable_revalidate: 1 // Revalidate immediately
+    };
+  }
+
   return {
     props: {
-      ...await fetchPrimaryShop(lang),
-      ...await fetchTranslations(lang, ["common"])
-    }
+      ...primaryShop,
+      ...translations
+    },
+    // eslint-disable-next-line camelcase
+    unstable_revalidate: 120 // Revalidate each two minutes
   };
 }
 


### PR DESCRIPTION
Signed-off-by: Janus Reith <mail@janusreith.de>

Resolves #697
Impact: **major**
Type: **feature|bugfix|performance|test|style|refactor|docs|chore**

## Issue
The shop is not present during the default CI build and no revalidation is set for that page. the shop id stays undefined and the query for catalog items is skipped.

## Solution
Set a revalidation time for that page, check if no shop is present and return fallback values that will require immedate revalidation.


## Testing
1. Run the production build
2. Visit the index page, no catalog items come up

## Additional context
As discussed with @willopez, we should somehow make sure that this is actually discouraged for production builds, as depoyments should not feature an initial render that is blank until the revalidated page is returned for subsequent requests.