### PR TITLE
Set _isMounted to true after component mounted

### DIFF
--- a/components/CheckoutActions/CheckoutActions.js
+++ b/components/CheckoutActions/CheckoutActions.js
@@ -69,6 +69,10 @@ class CheckoutActions extends Component {
     }
   }
 
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
   componentWillUnmount() {
     this._isMounted = false;
   }


### PR DESCRIPTION
Signed-off-by: Janus Reith <mail@janusreith.de>

Resolves #699
Impact: **minor**
Type: **bugfix**

## Issue
In https://github.com/reactioncommerce/example-storefront/commit/0ae583eb5f3f7a96270d968b536c770773a3cc38#diff-9b6019bce1be1df5431a56f4a139663dL77 I removed the whole `componentDidMount` part, not realizing that `this._isMounted = true;` was unrelated to the tracking events underneath.

## Solution
Add back a `componentDidMount` lifecycle function to set `_isMounted` to true in the first place.
Don't close #699 until confirmed that there is no separate issue present on older versions, where the component might actually not be mounted properly.

## Testing
See #699
