### PR TITLE
fix: don't execute unnecessary requests for anonymous cart on initial load

### DIFF
--- a/hooks/cart/useCart.js
+++ b/hooks/cart/useCart.js
@@ -51,7 +51,7 @@ export default function useCart() {
 
   const [
     fetchAnonymousCart,
-    { data: cartDataAnonymous, called: anonymousCartQueryCalled, refetch: refetchCartAnonymous }
+    { data: cartDataAnonymous, called: anonymousCartQueryCalled, refetch: refetchAnonymousCart }
   ] = useLazyQuery(anonymousCartByCartIdQuery, {
     variables: {
       cartId: cartStore.anonymousCartId,
@@ -71,7 +71,7 @@ export default function useCart() {
       refetchAccountCart();
     }
     if (!shouldSkipAnonymousCartByCartIdQuery && anonymousCartQueryCalled) {
-      refetchCartAnonymous();
+      refetchAnonymousCart();
     }
   }, [viewer, refetchAccountCart]);
 
@@ -126,7 +126,7 @@ export default function useCart() {
       if (accountCartId) {
         refetchAccountCart();
       } else if (anonymousCartToken) {
-        refetchCartAnonymous();
+        refetchAnonymousCart();
       }
     }
   });

--- a/hooks/cart/useCart.js
+++ b/hooks/cart/useCart.js
@@ -37,7 +37,10 @@ export default function useCart() {
   const shouldSkipAccountCartByAccountIdQuery = Boolean(!accountId || cartStore.hasAnonymousCartCredentials || isLoadingViewer || !shop || !shop._id);
   const shouldSkipAnonymousCartByCartIdQuery = Boolean(accountId || isLoadingViewer || !cartStore.anonymousCartId || !cartStore.anonymousCartToken);
 
-  const [fetchAccountCart, { loading: isLoading, called: accountCartQueryCalled,  data: cartData, fetchMore, refetch: refetchAccountCart }] = useLazyQuery(accountCartByAccountIdQuery, {
+  const [
+    fetchAccountCart,
+    { loading: isLoading, called: accountCartQueryCalled, data: cartData, fetchMore, refetch: refetchAccountCart }
+  ] = useLazyQuery(accountCartByAccountIdQuery, {
     variables: {
       accountId,
       shopId: shop && shop._id
@@ -46,7 +49,10 @@ export default function useCart() {
   });
 
 
-  const [fetchAnonymousCart, { data: cartDataAnonymous, called: anonymousCartQueryCalled, refetch: refetchCartAnonymous }] = useLazyQuery(anonymousCartByCartIdQuery, {
+  const [
+    fetchAnonymousCart,
+    { data: cartDataAnonymous, called: anonymousCartQueryCalled, refetch: refetchCartAnonymous }
+  ] = useLazyQuery(anonymousCartByCartIdQuery, {
     variables: {
       cartId: cartStore.anonymousCartId,
       cartToken: cartStore.anonymousCartToken
@@ -62,7 +68,7 @@ export default function useCart() {
 
   useEffect(() => {
     if (!shouldSkipAccountCartByAccountIdQuery && accountCartQueryCalled) {
-     refetchAccountCart();
+      refetchAccountCart();
     }
     if (!shouldSkipAnonymousCartByCartIdQuery && anonymousCartQueryCalled) {
       refetchCartAnonymous();
@@ -120,7 +126,7 @@ export default function useCart() {
       if (accountCartId) {
         refetchAccountCart();
       } else if (anonymousCartToken) {
-       refetchCartAnonymous();
+        refetchCartAnonymous();
       }
     }
   });
@@ -222,7 +228,7 @@ export default function useCart() {
               // Refetch cart
               if (accountCartQueryCalled) {
                 refetchAccountCart();
-               }
+              }
             }
           }
 

--- a/pages/[lang]/cart/login.js
+++ b/pages/[lang]/cart/login.js
@@ -85,7 +85,7 @@ const Login = ({ router }) => {
     isLoadingCart,
     setEmailOnAnonymousCart
   } = useCart();
-  const hasIdentity = !!((cart && cart.account !== null) || (cart && cart.email));
+  const hasIdentity = !!((cart && cart.account) || (cart && cart.email));
   const pageTitle = `Login | ${shop && shop.name}`;
 
   useEffect(() => {

--- a/pages/api/account/token.js
+++ b/pages/api/account/token.js
@@ -2,7 +2,7 @@ import passportMiddleware from "apiUtils/passportMiddleware";
 
 const token = async (req, res) => {
   req.session.redirectTo = req.headers.Referer;
-  if (req.session && req.session.passport) {
+  if (req.session && req.session.passport && req.session.passport.user) {
     try {
       const user = JSON.parse(req.session.passport.user);
       const { accessToken } = user;

--- a/pages/api/account/token.js
+++ b/pages/api/account/token.js
@@ -17,7 +17,7 @@ const token = async (req, res) => {
     }
   }
 
-  return res.status(401).send(JSON.stringify({ error: "No authorization data present" }));
+  return res.status(200).send(JSON.stringify({ anonymous: true }));
 };
 
 export default passportMiddleware(token);


### PR DESCRIPTION
Resolves #701 
Impact: **minor**
Type: **bugfix**

## Issue
1. Unnecessary requests for anonymous cart are executed when they should not. The anonymous cart query should only executed after a user has added an item to their cart.
2. An error was being returned by an api route when the user was anonymous, it should not be an error, just a flag that says that the user is anonymous.

## Solution
1. Use `lazyQuery`s to control when cart requests are executed.
2. Return a boolean flag `anonymous` to denote when a user is anonymous

## Breaking changes

## Testing
1. Load product grid and verify no `anonymousCartByCartIdQuery` request are executed.
2. Add and remove items to and from the cart and verify they are add/removed as expected.
3. Complete a checkout flow and place an order
4. Verify there are no error for the `api/token` route
