### PR TITLE
release v2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.9.3
+
+Example Storefront v2.9.3 is a patch update to keep this project in sync with [Reaction v2.9.3](https://github.com/reactioncommerce/reaction).
+
 # v2.9.2
 
 Example Storefront v2.9.2 is a patch update to keep this project in sync with [Reaction v2.9.2](https://github.com/reactioncommerce/reaction).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Example Storefront v2.9.3 is a patch update to keep this project in sync with [Reaction v2.9.3](https://github.com/reactioncommerce/reaction).
 
+## Reaction v2 EOL
+
+This is the final release of Reaction v2 software. As of September 1, 2020, Reaction v2 is no longer supported. We encourage everyone to upgrade to Reaction v3. Please see the [Upgrading from 2.x](https://docs.reactioncommerce.com/docs/upgrading) guide in our docs.
+
 # v2.9.2
 
 Example Storefront v2.9.2 is a patch update to keep this project in sync with [Reaction v2.9.2](https://github.com/reactioncommerce/reaction).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "The Example Storefront serves as a reference for implementing a web based storefront using the Reaction Commerce GraphQL API.",
   "main": "./src/server.js",
   "keywords": [],


### PR DESCRIPTION
# v2.9.3

Example Storefront v2.9.3 is a patch update to keep this project in sync with [Reaction v2.9.3](https://github.com/reactioncommerce/reaction).