### PR TITLE
Don't get shop to pre-render page

### DIFF
--- a/pages/[lang]/cart.js
+++ b/pages/[lang]/cart.js
@@ -16,7 +16,6 @@ import Router from "translations/i18nRouter";
 import PageLoading from "components/PageLoading";
 import { withApollo } from "lib/apollo/withApollo";
 
-import { locales } from "translations/config";
 import fetchPrimaryShop from "staticUtils/shop/fetchPrimaryShop";
 import fetchTranslations from "staticUtils/translations/fetchTranslations";
 
@@ -177,29 +176,17 @@ class CartPage extends Component {
 }
 
 /**
- *  Static props for the cart route
+ *  Server props for the cart route
  *
  * @param {String} lang - the shop's language
  * @returns {Object} props
  */
-export async function getStaticProps({ params: { lang } }) {
+export async function getServerSideProps({ params: { lang } }) {
   return {
     props: {
       ...await fetchPrimaryShop(lang),
       ...await fetchTranslations(lang, ["common"])
     }
-  };
-}
-
-/**
- *  Static paths for the cart route
- *
- * @returns {Object} paths
- */
-export async function getStaticPaths() {
-  return {
-    paths: locales.map((locale) => ({ params: { lang: locale } })),
-    fallback: false
   };
 }
 

--- a/pages/[lang]/index.js
+++ b/pages/[lang]/index.js
@@ -98,7 +98,7 @@ export async function getStaticProps({ params: { lang } }) {
   const primaryShop = await fetchPrimaryShop(lang);
   const translations = await fetchTranslations(lang, ["common"]);
 
-  if (!primaryShop) {
+  if (!primaryShop?.shop) {
     return {
       props: {
         shop: null,

--- a/pages/[lang]/product/[...slugOrId].js
+++ b/pages/[lang]/product/[...slugOrId].js
@@ -134,7 +134,7 @@ export async function getStaticProps({ params: { slugOrId, lang } }) {
   const productSlug = slugOrId && slugOrId[0];
   const primaryShop = await fetchPrimaryShop(lang);
 
-  if (!primaryShop) {
+  if (!primaryShop?.shop) {
     return {
       props: {
         shop: null,

--- a/pages/[lang]/tag/[slug].js
+++ b/pages/[lang]/tag/[slug].js
@@ -161,7 +161,7 @@ class TagGridPage extends Component {
 export async function getStaticProps({ params: { lang, slug } }) {
   const primaryShop = await fetchPrimaryShop(lang);
 
-  if (!primaryShop) {
+  if (!primaryShop?.shop) {
     return {
       props: {
         shop: null,


### PR DESCRIPTION
Resolves #742 
Impact: **critical**
Type: **bugfix**

## Issue
The cart page was being saved on build time, which was causing the `shop` to null as there was no server to get the shop from during build time.
Also the all the pages were being re-built after 2 mins, because of a wrong variable check.

## Solution
Now the shop would be fetched from the backend on every request. Fixed the variable check to recreate the page when the `shop` is not present.

## Breaking changes
None expected.

## Testing
1. Start the platform using `make`
2. Stop `reaction_api` using `docker stop reaction_api_1`. This would simulate the circle CI build env in which the server is not running.
3. Build the example-storefront image using `docker build --network=host -t  reactioncommerce/example-storefront:test-me .` in `example-storefront` directory
4. Once complete get the server back up using `make init-reaction`
5. Run the new image using `docker run -it --name storefront -p 4000:4000 --env-file .env.prod --network reaction.localhost reactioncommerce/example-storefront:test-me`. If you get an error that `/storefront` is being used by XXX, do `docker rm XXX`
6. Login, try adding products to cart, go to cart page. Everything should work.

There are other pages that use `unstable_revalidate`, but I was getting very sketchy behavior on the first load using that. So I thought it might be better to remove SSR for now, and if needed people can extend and add that according to their need. The behaviour is explained in the linked issue.