### PR TITLE
Fix: changes made to address book does not reflect in UI

### DIFF
--- a/hooks/address/useAddAccountAddressBookEntry.js
+++ b/hooks/address/useAddAccountAddressBookEntry.js
@@ -8,7 +8,7 @@ import { addAccountAddressBookEntryMutation } from "./mutations.gql";
  * @returns {Array} The added address book entry
  */
 export default function useAddAccountAddressBookEntry() {
-  const [viewer, refetchViewer] = useViewer();
+  const [viewer, , refetchViewer] = useViewer();
 
   const [addAccountAddressBookEntryFunc, { loading }] = useMutation(addAccountAddressBookEntryMutation, {
     onCompleted() {

--- a/hooks/address/useRemoveAccountAddressBookEntry.js
+++ b/hooks/address/useRemoveAccountAddressBookEntry.js
@@ -8,7 +8,7 @@ import { removeAccountAddressBookEntryMutation } from "./mutations.gql";
  * @returns {Array} A list of removed address book entries
  */
 export default function useRemoveAccountAddressBookEntry() {
-  const [viewer, refetchViewer] = useViewer();
+  const [viewer, , refetchViewer] = useViewer();
 
   const [removeAccountAddressBookEntryFunc, { loading }] = useMutation(removeAccountAddressBookEntryMutation, {
     onCompleted() {

--- a/hooks/address/useUpdateAccountAddressBookEntry.js
+++ b/hooks/address/useUpdateAccountAddressBookEntry.js
@@ -8,7 +8,7 @@ import { updateAccountAddressBookEntryMutation } from "./mutations.gql";
  * @returns {Array} A list of updated address book entries
  */
 export default function useUpdateAccountAddressBookEntry() {
-  const [viewer, refetchViewer] = useViewer();
+  const [viewer, , refetchViewer] = useViewer();
 
   const [updateAccountAddressBookEntryFunc, { loading }] = useMutation(updateAccountAddressBookEntryMutation, {
     onCompleted() {


### PR DESCRIPTION
Signed-off-by: jrw421 <jessica.wolvington@gmail.com>

Resolves #744 
Impact: **minor**
Type: **bugfix**

## Issue
Upon adding a new address or deleting an address the changes do not reflect immediately on UI. It only takes effect after browser refresh. The changes are persisted at DB level. Deleting a pre deleted address gives an appropriate address not found GraphQL error.

Steps to reproduce the behavior: 

1. On the storefront UI go to Profile - > Address Book
2. Add or delete an address.
3. Navigate to Orders on the same page and go back to Address Book. The list is not updated with the cahange.
4. Navigate out of the profile page (maybe home page or cart. Explore some products). Go back to address book. The list is not updated with the change.
5. Refresh the browser. The list is now updated with the change.

## Solution
This was solved by adding a placeholder in the destructuring of the useViewer hook. It's possible that the hook was updated and the add/delete account files were not updated to reflect the change. The useViewer hook exports three items, the last of which was necessary to reflect the updates to the addresses (`refetchViewer`). Since the original code was only destructuring two items, the `refetchViewer` was ultimately the wrong item and wasn't being called as expected.

**Note:** The unused import is being destructured as an empty string to avoid `no-unused-var` linting issues. Happy to alter this if preferred. 

## Breaking changes
None expected.

## Testing
1. On the storefront UI go to Profile - > Address Book
2. Add or delete an address. 
3. The changes should immediately be reflected in the address book.

