### PR TITLE
(bugfix): pinning docker to higher version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 19.03.13
       - run:
           name: Lint Dockerfiles
           command: ${CI_SCRIPTS} lint-dockerfiles
@@ -82,6 +83,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 19.03.13
       - run:
           name: Build and push production Docker image
           command: ${CI_SCRIPTS} docker-build-tag-push . ${DOCKER_REPOSITORY}


### PR DESCRIPTION
Resolves: #748 
Impact: critical

**Issue**:
The default version of docker being pulled had this problem. The CircleCI support suggested to upgrade [here](https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-)

**Resolution**:
Pinned the version of docker to the latest version. 