### PR TITLE
Fix: Error on PDP when product is missing slug

### DIFF
--- a/components/CatalogGridItem/CatalogGridItem.js
+++ b/components/CatalogGridItem/CatalogGridItem.js
@@ -214,7 +214,6 @@ class CatalogGridItem extends Component {
 
   render() {
     const { className, badgeLabels, components: { BadgeOverlay }, product } = this.props;
-
     const { slug } = product;
     const badgeProps = { product };
 
@@ -225,8 +224,8 @@ class CatalogGridItem extends Component {
     return (
       <div className={className}>
         <Link
-          href="/product/[...slugOrId]"
-          as={`/product/${slug}`}
+          href={slug && `/product/[...slugOrId]`}
+          as={slug && `/product/${slug}`}
         >
           <BadgeOverlay {...badgeProps}>
             {this.renderProductMedia()}

--- a/components/CatalogGridItem/CatalogGridItem.js
+++ b/components/CatalogGridItem/CatalogGridItem.js
@@ -225,7 +225,7 @@ class CatalogGridItem extends Component {
     return (
       <div className={className}>
         <Link
-          href={slug && `/product/[...slugOrId]`}
+          href={slug && "/product/[...slugOrId]"}
           as={slug && `/product/${slug}`}
         >
           <BadgeOverlay {...badgeProps}>

--- a/components/CatalogGridItem/CatalogGridItem.js
+++ b/components/CatalogGridItem/CatalogGridItem.js
@@ -214,6 +214,7 @@ class CatalogGridItem extends Component {
 
   render() {
     const { className, badgeLabels, components: { BadgeOverlay }, product } = this.props;
+    
     const { slug } = product;
     const badgeProps = { product };
 

--- a/components/CatalogGridItem/CatalogGridItem.js
+++ b/components/CatalogGridItem/CatalogGridItem.js
@@ -214,7 +214,7 @@ class CatalogGridItem extends Component {
 
   render() {
     const { className, badgeLabels, components: { BadgeOverlay }, product } = this.props;
-    
+
     const { slug } = product;
     const badgeProps = { product };
 


### PR DESCRIPTION
Resolves #750
Impact: **minor**
Type: **bugfix**

## Issue
When a product was saved without a title and published to the storefront and the customer tries to open PDP for that product, the system throws `404 Not Found error` (in case of Mac) and `Sorry! We couldn't find what you're looking for` error (in case of Ubuntu). Related to https://github.com/reactioncommerce/reaction-admin/issues/304. 

## Solution
Only make the link to the PDP available if there is a slug present. If there is a slug, the product links to the product page as expected. Otherwise the product page does not link without a valid slug. If there's a more graceful way of avoiding this error I'm happy to chat through it! 

## Breaking changes
None expected.

## Testing

1. From reaction admin, create a product without its title (and thus, slug)
2. Publish this product
3. From storefront, click on the product without title
4. The click should not link out to the product page or cause the page to error out.
5. Click on a product with a valid slug. 
6. This should bring you to the PDP without issue.

