### PR TITLE
Release v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v4.0.1
+Example Storefront v4.0.1 adds minor features and performance enhancements, and does contain breaking changes since v4.0.1
+
+## Fixes
+fix: changes made to address book does not reflect in UI ([#747](https://github.com/reactioncommerce/example-storefront/pull/747))
+fix: Error on PDP when product is missing slug ([#751](https://github.com/reactioncommerce/example-storefront/pull/751))
+fix: pinning docker to higher version ([#749](https://github.com/reactioncommerce/example-storefront/pull/749))
+
+## Chores
+chore: add package-link file to storefront ([#745](https://github.com/reactioncommerce/example-storefront/pull/745))
+
 # v4.0.0
 
 Example Storefront v4.0.0 adds major features and performance enhancements, and does contain breaking changes since v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v4.0.1
-Example Storefront v4.0.1 adds minor features and performance enhancements, and does contain breaking changes since v4.0.1
+Example Storefront v4.0.1 adds minor features, and does contain breaking changes since v4.0.1
 
 ## Fixes
 fix: changes made to address book does not reflect in UI ([#747](https://github.com/reactioncommerce/example-storefront/pull/747))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ networks:
 
 services:
   web:
-    image: reactioncommerce/example-storefront:4.0.0
+    image: reactioncommerce/example-storefront:4.0.1
     env_file:
       - ./.env
     networks:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-storefront",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The Example Storefront serves as a reference for implementing a web based storefront using the Reaction Commerce GraphQL API.",
   "keywords": [],
   "author": {


### PR DESCRIPTION
# v4.0.1
Example Storefront v4.0.1 adds minor features, and does contain breaking changes since v4.0.1

## Fixes
- fix: changes made to address book does not reflect in UI ([#747](https://github.com/reactioncommerce/example-storefront/pull/747))
- fix: Error on PDP when product is missing slug ([#751](https://github.com/reactioncommerce/example-storefront/pull/751))
- fix: pinning docker to higher version ([#749](https://github.com/reactioncommerce/example-storefront/pull/749))

## Chores
- chore: add package-link file to storefront ([#745](https://github.com/reactioncommerce/example-storefront/pull/745))