### PR TITLE
fix: add babel entry to accommodate styles components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,15 @@
 {
   "presets": [
     "next/babel"
+  ],
+  "plugins": [
+    [
+      "styled-components",
+      {
+        "ssr": true,
+        "displayName": true,
+        "preprocess": false
+      }
+    ]
   ]
 }


### PR DESCRIPTION
Signed-off-by: Brent Hoover <brent@thebuddhalodge.com>

Impact: **minor**
Type: **bugfix**

## Issue

When switching to Node 14 get this error and some styles do not load:

`Prop `className` did not match. Server: "makeStyles-anchor-11" Client: "makeStyles-anchor-8`

Seems to be [this issue](https://github.com/vercel/next.js/issues/7322) 

## Solution

Add a section to babelrc that makes sure that class names are the same on client and server.


## Breaking changes

None

## Testing

1. Do a fresh clone of this branch
2. Switch to Node 14
3. Do `yarn run start:dev`
4. Observe that the site loads all styles correctly
